### PR TITLE
[ton-client-web] Platform builder generates ready to use `index.js` f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+## May 19, 2020
+### ton-client-web 0.23.1
+#### New
+- Platform builder generates ready to use `index.js` for web clients (instead of install script of `ton-client-web-js` binding)
+
 ## May 17, 2020
 ### New
 - `tvm.get` now can fetch account data if it is not provided

--- a/ton_client/platforms/build-lib.js
+++ b/ton_client/platforms/build-lib.js
@@ -89,6 +89,7 @@ module.exports = {
     deleteFolderRecursive,
     main,
     gz,
+    toml_version,
     version,
     root_path,
 };

--- a/ton_client/platforms/ton-client-web/Cargo.toml
+++ b/ton_client/platforms/ton-client-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_web"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2018"
 description = "tonsdk WASM binding"
 license = "Apache-2.0"

--- a/ton_client/platforms/ton-client-web/build-index.js
+++ b/ton_client/platforms/ton-client-web/build-index.js
@@ -1,0 +1,138 @@
+
+// This file is just a template that used to generate index.js at npm installation stage
+
+import { TONClient } from 'ton-client-js';
+
+const workerScript = '';
+
+//---
+
+const wasmOptions = {
+    debugLog: null,
+    binaryURL: '/tonclient.wasm',
+};
+
+function debugLog(message) {
+    if (wasmOptions.debugLog) {
+        wasmOptions.debugLog(message);
+    }
+}
+
+const createLibrary = async () => {
+    const workerBlob = new Blob(
+        [workerScript],
+        { type: 'application/javascript' }
+    );
+    const workerUrl = URL.createObjectURL(workerBlob);
+    const worker = new Worker(workerUrl);
+
+    const activeRequests = new Map();
+
+    // Deferred requests are accumulated before WASM module have been loaded
+    let deferredRequests = [];
+
+    let nextActiveRequestId = 1;
+
+    worker.onerror = (evt) => {
+        console.log(`Error from Web Worker: ${evt.message}`);
+    };
+
+    const library = {
+        request: (method, params, callback) => {
+            if (method === 'version') {
+                callback('"__VERSION__"', '');
+                return;
+            }
+            const id = nextActiveRequestId;
+            nextActiveRequestId += 1;
+            const request = {
+                id,
+                method,
+                params,
+            };
+            const isDeferredSetup = (method === 'setup') && (deferredRequests !== null);
+            activeRequests.set(id, {
+                callback: isDeferredSetup ? () => {} : callback
+            });
+            if (deferredRequests !== null) {
+                deferredRequests.push(request);
+            } else {
+                worker.postMessage({ request });
+            }
+            if (isDeferredSetup) {
+                callback('', '');
+            }
+        },
+    };
+
+    worker.onmessage = (evt) => {
+        const setup = evt.data.setup;
+        if (setup) {
+            for (const request of deferredRequests) {
+                worker.postMessage({ request });
+            }
+            deferredRequests = null;
+            return;
+        }
+
+        const response = evt.data.response;
+        if (response) {
+            const activeRequest = activeRequests.get(response.id);
+            if (!activeRequest) {
+                return;
+            }
+            activeRequests.delete(response.id);
+            if (activeRequest.callback) {
+                let { result } = response;
+                // Remove BOM from result
+                result = result.charCodeAt(0) === 0xFEFF ? result.substr(1) : result;
+                const { result_json, error_json } = JSON.parse(result);
+                activeRequest.callback(result_json, error_json);
+            }
+        }
+    };
+
+    (async () => {
+        const e = Date.now();
+        let wasmModule;
+        const fetched = fetch(wasmOptions.binaryURL);
+        if (WebAssembly.compileStreaming) {
+            debugLog('compileStreaming binary');
+            wasmModule = await WebAssembly.compileStreaming(fetched);
+        } else {
+            debugLog('compile binary');
+            wasmModule = await WebAssembly.compile(await (await fetched).arrayBuffer());
+        }
+        worker.postMessage({
+            setup: {
+                wasmModule,
+            }
+        });
+        debugLog(`compile time ${Date.now() - e}`);
+    })();
+
+    return Promise.resolve(library);
+};
+
+function setWasmOptions(options) {
+    Object.assign(wasmOptions, options);
+}
+
+const clientPlatform = {
+    fetch,
+    WebSocket,
+    createLibrary,
+};
+
+TONClient.setLibrary({
+    fetch,
+    WebSocket,
+    createLibrary
+});
+
+export {
+    createLibrary,
+    setWasmOptions,
+    clientPlatform,
+    TONClient
+};

--- a/ton_client/platforms/ton-client-web/build-worker.js
+++ b/ton_client/platforms/ton-client-web/build-worker.js
@@ -1,0 +1,31 @@
+const wasmWrapper = {
+    setup(instance) {
+    }
+};
+//---
+self.onmessage = (e) => {
+    const message = e.data;
+    const setup = message.setup;
+    if (setup) {
+        (async () => {
+            const instance = (await WebAssembly.instantiate(setup.wasmModule, {
+                wbg: wasmWrapper.wbg
+            })).exports;
+            wasmWrapper.setup(instance);
+            postMessage({
+                setup: {}
+            })
+        })();
+        return;
+    }
+    const request = message.request;
+    if (request) {
+        const result = wasmWrapper.request(request.method, request.params);
+        postMessage({
+            response: {
+                id: request.id,
+                result,
+            }
+        });
+    }
+};

--- a/ton_client/platforms/ton-client-web/build.js
+++ b/ton_client/platforms/ton-client-web/build.js
@@ -1,13 +1,78 @@
 const fs = require('fs');
-const {gz, spawnProcess, deleteFolderRecursive, main, version, root_path} = require('../build-lib');
+const path = require('path');
+const {
+    gz,
+    spawnProcess,
+    deleteFolderRecursive,
+    main,
+    toml_version,
+    version,
+    root_path
+} = require('../build-lib');
+
+function scriptToStringLiteral(s) {
+    return `\`${s.split('`').join('\\``')}\``;
+}
+
+function getTemplate(name) {
+    const template = fs.readFileSync(path.resolve(__dirname, name), 'utf-8').split('//---');
+    if (template.length > 1) {
+        template.shift();
+    }
+    return template.join('');
+}
+
+function getWasmWrapperScript() {
+    let script = fs.readFileSync(path.resolve(__dirname, 'pkg', 'ton_client_web.js'), 'utf-8');
+    script = script.replace(
+        /^let wasm;$/gm,
+        `
+const wasmWrapper = (function() {
+let wasm = null;
+const result = {
+    setup: (newWasm) => {
+        wasm = newWasm;
+    },
+};
+`,
+    );
+    script = script.replace(/^export const /gm, 'result.');
+    script = script.replace(/^export function (\w+)/gm, 'result.$1 = function');
+    script = script.replace(/^async function load\([^]*?^}$/gm, '');
+    script = script.replace(/^async function init\([^]*?^\s*const imports = {};$/gm, '');
+    script = script.replace(/^\s*if \(typeof input === [^]*/gm, '');
+    script = script.replace(/^\s*imports\.wbg/gm, '    result.wbg');
+    script +=
+        `   return result;
+})()`;
+    return script;
+}
+
+function getWorkerScript() {
+    return [
+        getWasmWrapperScript(),
+        getTemplate('build-worker.js'),
+    ].join('\n');
+}
+
+function getIndexScript() {
+    const workerScript = getWorkerScript();
+    const script = [
+        `import { TONClient } from 'ton-client-js';`,
+        `const workerScript = ${scriptToStringLiteral(workerScript)};`,
+        getTemplate('build-index.js').replace('__VERSION__', toml_version),
+    ];
+    return script.join('\n');
+}
 
 
-main(async() => {
+main(async () => {
     // await spawnProcess('cargo', ['clean']);
-    await spawnProcess('cargo', ['update']);
+    // await spawnProcess('cargo', ['update']);
     await spawnProcess('wasm-pack', ['build', '--release', '--target', 'web']);
+    fs.writeFileSync(path.resolve(__dirname, 'pkg', 'index.js'), getIndexScript(), { encoding: 'utf8' });
     deleteFolderRecursive(root_path('bin'));
     fs.mkdirSync(root_path('bin'), { recursive: true });
     await gz(['pkg', 'ton_client_web_bg.wasm'], `tonclient_${version}_wasm`);
-    await gz(['pkg', 'ton_client_web.js'], `tonclient_${version}_wasm_js`);
+    await gz(['pkg', 'index.js'], `tonclient_${version}_wasm_js`);
 });

--- a/ton_client/platforms/ton-client-web/build.js
+++ b/ton_client/platforms/ton-client-web/build.js
@@ -68,7 +68,7 @@ function getIndexScript() {
 
 main(async () => {
     // await spawnProcess('cargo', ['clean']);
-    // await spawnProcess('cargo', ['update']);
+    await spawnProcess('cargo', ['update']);
     await spawnProcess('wasm-pack', ['build', '--release', '--target', 'web']);
     fs.writeFileSync(path.resolve(__dirname, 'pkg', 'index.js'), getIndexScript(), { encoding: 'utf8' });
     deleteFolderRecursive(root_path('bin'));


### PR DESCRIPTION
…or web clients (instead of install script of `ton-client-web-js` binding)