### PR TITLE
Account emulation

### DIFF
--- a/ton_client/client/src/json_interface/modules.rs
+++ b/ton_client/client/src/json_interface/modules.rs
@@ -314,6 +314,7 @@ pub struct TvmModule;
 fn register_tvm(handlers: &mut RuntimeHandlers) {
     let mut module = ModuleReg::new::<TvmModule>(handlers);
     module.register_type::<crate::tvm::types::ExecutionOptions>();
+    module.register_type::<crate::tvm::AccountForExecutor>();
     module.register_async_fn(
         crate::tvm::run_executor,
         crate::tvm::run_message::run_executor_api,

--- a/ton_client/client/src/processing/fetching.rs
+++ b/ton_client/client/src/processing/fetching.rs
@@ -156,7 +156,7 @@ pub async fn fetch_transaction_result(
         Ok((address, balance))
     };
     let transaction_object = deserialize_object_from_base64(&transaction_boc.boc, "transaction")?;
-    let fees = check_transaction(&transaction_object.object, true, get_contract_info).await?;
+    let fees = check_transaction(&transaction_object.object, true, false, get_contract_info).await?;
     let (transaction, out_messages) = parse_transaction_boc(context.clone(), transaction_boc)?;
     let abi_decoded = if let Some(abi) = abi {
         Some(decode_output(context, abi, out_messages.clone())?)

--- a/ton_client/client/src/processing/fetching.rs
+++ b/ton_client/client/src/processing/fetching.rs
@@ -9,7 +9,7 @@ use crate::processing::internal::{
 };
 use crate::processing::parsing::{decode_output, parse_transaction_boc};
 use crate::tvm::{ExitCode};
-use crate::tvm::check_transaction::check_transaction;
+use crate::tvm::check_transaction::calc_transaction_fees;
 use crate::processing::{
     Error, ParamsOfWaitForTransaction, ProcessingEvent, ResultOfProcessMessage,
 };
@@ -156,7 +156,7 @@ pub async fn fetch_transaction_result(
         Ok((address, balance))
     };
     let transaction_object = deserialize_object_from_base64(&transaction_boc.boc, "transaction")?;
-    let fees = check_transaction(&transaction_object.object, true, false, get_contract_info).await?;
+    let fees = calc_transaction_fees(&transaction_object.object, true, false, get_contract_info).await?;
     let (transaction, out_messages) = parse_transaction_boc(context.clone(), transaction_boc)?;
     let abi_decoded = if let Some(abi) = abi {
         Some(decode_output(context, abi, out_messages.clone())?)

--- a/ton_client/client/src/tvm/check_transaction.rs
+++ b/ton_client/client/src/tvm/check_transaction.rs
@@ -19,6 +19,7 @@ use std::convert::TryFrom;
 pub(crate) async fn check_transaction<F>(
     transaction: &ton_block::Transaction,
     real_tr: bool,
+    skip_check: bool,
     contract_info: impl FnOnce() -> F,
 ) -> ClientResult<ton_sdk::TransactionFees>
 where 
@@ -27,7 +28,7 @@ where
     let transaction = ton_sdk::Transaction::try_from(transaction)
         .map_err(|err| Error::can_not_read_transaction(err))?;
 
-    if !transaction.is_aborted() {
+    if !transaction.is_aborted() || skip_check {
         return Ok(transaction.calc_fees());
     }
 

--- a/ton_client/client/src/tvm/check_transaction.rs
+++ b/ton_client/client/src/tvm/check_transaction.rs
@@ -16,7 +16,7 @@ use crate::error::ClientResult;
 use ton_block::AccStatusChange;
 use std::convert::TryFrom;
 
-pub(crate) async fn check_transaction<F>(
+pub(crate) async fn calc_transaction_fees<F>(
     transaction: &ton_block::Transaction,
     real_tr: bool,
     skip_check: bool,

--- a/ton_client/client/src/tvm/errors.rs
+++ b/ton_client/client/src/tvm/errors.rs
@@ -23,7 +23,7 @@ pub enum ErrorCode {
     CanNotReadTransaction = TVM + 1,
     CanNotReadBlockchainConfig = TVM + 2,
     TransactionAborted = TVM + 3,
-    ContractExecutionError = TVM + 4,
+    InternalError = TVM + 4,
     ActionPhaseFailed = TVM + 5,
     AccountCodeMissing = TVM + 6,
     LowBalance = TVM + 7,
@@ -33,7 +33,7 @@ pub enum ErrorCode {
     InvalidInputStack = TVM + 11,
     InvalidAccountBoc = TVM + 12,
     InvalidMessageType = TVM + 13,
-    InternalError = TVM + 14,
+    ContractExecutionError = TVM + 14,
 }
 pub struct Error;
 

--- a/ton_client/client/src/tvm/mod.rs
+++ b/ton_client/client/src/tvm/mod.rs
@@ -26,7 +26,7 @@ mod tests;
 pub use errors::{Error, ErrorCode};
 pub use run_get::{run_get, ParamsOfRunGet, ResultOfRunGet};
 pub use run_message::{
-    run_executor, run_tvm, ParamsOfRunExecutor, ParamsOfRunTvm,
+    run_executor, run_tvm, AccountForExecutor, ParamsOfRunExecutor, ParamsOfRunTvm,
     ResultOfRunExecutor, ResultOfRunTvm
 };
 pub use types::{ExitCode, ExecutionOptions};

--- a/ton_client/client/src/tvm/tests.rs
+++ b/ton_client/client/src/tvm/tests.rs
@@ -120,7 +120,7 @@ async fn test_run_executor() {
             .call(ParamsOfRunExecutor {
                 message: message.message.clone(),
                 abi: Some(abi.clone()),
-                account: AccountForExecutor::State {
+                account: AccountForExecutor::Account {
                     boc: account.clone(),
                     unlimited_balance: Some(true)
                 },
@@ -142,7 +142,7 @@ async fn test_run_executor() {
             .call(ParamsOfRunExecutor {
                 message: message.message,
                 abi: Some(abi.clone()),
-                account: AccountForExecutor::State {
+                account: AccountForExecutor::Account {
                     boc: account,
                     unlimited_balance: None
                 },


### PR DESCRIPTION
- `AccountForExecutor` enum for representing account state in `run_executor`
- unlimited balance feature
- uninited account option in `AccountForExecutor`