### PR TITLE
Fix naming and types in tonclient.h

### DIFF
--- a/ton_client/client/tonclient.h
+++ b/ton_client/client/tonclient.h
@@ -9,17 +9,17 @@ typedef struct {
 
 typedef struct tc_string_handle_t tc_string_handle_t;
 
-enum tc_response_types_t {
+typedef enum tc_response_types {
     tc_response_success = 0,
     tc_response_error = 1,
     tc_response_nop = 2,
     tc_response_custom = 100,
-};
+} tc_response_types_t;
 
 typedef void (*tc_response_handler_t)(
     uint32_t request_id,
     tc_string_data_t params_json,
-    uint32_t response_type,
+    tc_response_types_t response_type,
     bool finished);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Typedef for `tc_response_types` + using `tc_response_types_t` instead of `uint32_t` for `response_type` argument.