### PR TITLE
FIX: api type derivation uses `vec![]` instead of prev `[].into()` (t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Cargo.lock
 *.pdb
 *.exe
 *.rlib
+build/
 
 # IDE files
 .idea

--- a/api/derive/Cargo.toml
+++ b/api/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_derive"
-version = "0.1.0"
+version = "1.1.1"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/api/derive/src/utils.rs
+++ b/api/derive/src/utils.rs
@@ -129,7 +129,7 @@ pub(crate) fn function_to_tokens(m: &api_info::Function) -> TokenStream {
             name: #name.into(),
             summary: #summary,
             description: #description,
-            params: [#(#params), *].into(),
+            params: vec![#(#params), *],
             result: #result,
             errors: None,
         }
@@ -177,19 +177,19 @@ fn type_to_tokens(t: &api_info::Type) -> TokenStream {
         }
         api_info::Type::Struct { fields } => {
             let field_types = fields.iter().map(|x| field_to_tokens(x));
-            quote! { api_info::Type::Struct { fields: [#(#field_types),*].into() } }
+            quote! { api_info::Type::Struct { fields: vec![#(#field_types),*] } }
         }
         api_info::Type::EnumOfConsts { consts } => {
             let consts = consts.iter().map(|x| const_to_tokens(x));
-            quote! { api_info::Type::EnumOfConsts { consts: [#(#consts),*].into() } }
+            quote! { api_info::Type::EnumOfConsts { consts: vec![#(#consts),*] } }
         }
         api_info::Type::EnumOfTypes { types } => {
             let types = types.iter().map(|x| field_to_tokens(x));
-            quote! { api_info::Type::EnumOfTypes { types: [#(#types),*].into() } }
+            quote! { api_info::Type::EnumOfTypes { types: vec![#(#types),*] } }
         }
         api_info::Type::Generic { name, args } => {
             let types = args.iter().map(|x| type_to_tokens(x));
-            quote! { api_info::Type::Generic { name: #name.into(), args: [#(#types),*].into() } }
+            quote! { api_info::Type::Generic { name: #name.into(), args: vec![#(#types),*] } }
         }
     }
 }

--- a/api/info/Cargo.toml
+++ b/api/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_info"
-version = "0.1.0"
+version = "1.1.1"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/api/test/Cargo.toml
+++ b/api/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_test"
-version = "0.1.0"
+version = "1.1.1"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/ton_client/client/Cargo.toml
+++ b/ton_client/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Michael Vlasov"]
 edition = "2018"
 license = "Apache-2.0"

--- a/ton_client/client/Cargo.toml
+++ b/ton_client/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Michael Vlasov"]
 edition = "2018"
 license = "Apache-2.0"

--- a/ton_client/platforms/ton-client-node-js/Cargo.toml
+++ b/ton_client/platforms/ton-client-node-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_node_js"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["TON Labs"]
 license = "Apache-2.0"
 

--- a/ton_client/platforms/ton-client-web/Cargo.toml
+++ b/ton_client/platforms/ton-client-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_wasm"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2018"
 description = "TON Client WASM binding"
 license = "Apache-2.0"

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_sdk"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_sdk"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/toncli/Cargo.toml
+++ b/toncli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toncli"
-version = "1.1.1"
+version = "1.2.0"
 description = "TON CLient Command Line Tool"
 authors = ["TON DEV SOLUTIONS LTD <support@tonlabs.io>"]
 repository = "https://github.com/tonlabs/TON-SDK"

--- a/toncli/Cargo.toml
+++ b/toncli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toncli"
-version = "1.1.0"
+version = "1.1.1"
 description = "TON CLient Command Line Tool"
 authors = ["TON DEV SOLUTIONS LTD <support@tonlabs.io>"]
 repository = "https://github.com/tonlabs/TON-SDK"


### PR DESCRIPTION
…o be compatible with older rust version)