### PR TITLE
Version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+## 1.1.0 Nov 11, 2020
+### Fixed
+- api type derivation uses `vec![]` instead of prev `[].into()` (to be compatible with older rust version)
+
 ## 1.1.0 Nov 3, 2020
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
-## 1.1.0 Nov 11, 2020
+## 1.1.1 Nov 11, 2020
 ### Fixed
-- api type derivation uses `vec![]` instead of prev `[].into()` (to be compatible with older rust version)
+- To be compatible with older rust version change api type derivation with `vec![]`
+instead of prev `[].into()`
 
 ## 1.1.0 Nov 3, 2020
 

--- a/ton_client/platforms/ton-client-node-js/Cargo.toml
+++ b/ton_client/platforms/ton-client-node-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_node_js"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["TON Labs"]
 license = "Apache-2.0"
 

--- a/ton_client/platforms/ton-client-web/Cargo.toml
+++ b/ton_client/platforms/ton-client-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_wasm"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 description = "TON Client WASM binding"
 license = "Apache-2.0"


### PR DESCRIPTION
* FIX: api type derivation uses `vec![]` instead of prev `[].into()` (to be compatible with older rust version)