### PR TITLE
1.1.2 rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+## 1.1.2 Nov 12, 2020
+### Fixed
+- `client.factorize` doesn't panic on invalid challenge
+- `client.get_api_reference` returns proper version
+- ABI JSON with explicit function ID is parsed properly
+
 ## 1.1.1 Nov 11, 2020
 ### Fixed
 - To be compatible with older rust version change api type derivation with `vec![]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.1.2 Nov 12, 2020
 ### Fixed
-- `client.factorize` doesn't panic on invalid challenge
+- `crypto.factorize` doesn't panic on invalid challenge
 - `client.get_api_reference` returns proper version
 - ABI JSON with explicit function ID is parsed properly
 

--- a/api/derive/Cargo.toml
+++ b/api/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_derive"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/api/info/Cargo.toml
+++ b/api/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_info"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/api/test/Cargo.toml
+++ b/api/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_test"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Michael Vlasov <melsomino@gmail.com>"]
 edition = "2018"
 

--- a/ton_client/client/Cargo.toml
+++ b/ton_client/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Michael Vlasov"]
 edition = "2018"
 license = "Apache-2.0"

--- a/ton_client/client/src/abi/types.rs
+++ b/ton_client/client/src/abi/types.rs
@@ -57,7 +57,7 @@ pub struct AbiFunction {
     pub inputs: Vec<AbiParam>,
     pub outputs: Vec<AbiParam>,
     #[serde(default)]
-    pub id: Option<u32>,
+    pub id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType)]
@@ -65,7 +65,7 @@ pub struct AbiEvent {
     pub name: String,
     pub inputs: Vec<AbiParam>,
     #[serde(default)]
-    pub id: Option<u32>,
+    pub id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType)]

--- a/ton_client/client/src/client/tests.rs
+++ b/ton_client/client/src/client/tests.rs
@@ -32,4 +32,5 @@ fn api_reference() {
         crate::client::get_api_reference_api().name
     )).unwrap();
     assert_ne!(api.api.modules.len(), 0);
+    assert_eq!(api.api.version, env!("CARGO_PKG_VERSION"));
 }

--- a/ton_client/client/src/crypto/math.rs
+++ b/ton_client/client/src/crypto/math.rs
@@ -102,7 +102,7 @@ pub fn factorize(
         let mut y = x;
 
         let q = ((rng.next_u64() & 0xF) + 17) % composite;
-        let lim = 1 << (i + 18);
+        let lim = 1 << (std::cmp::min(i, 5) + 18);
 
         for j in 1..lim {
             it += 1;

--- a/ton_client/client/src/crypto/tests.rs
+++ b/ton_client/client/src/crypto/tests.rs
@@ -76,6 +76,14 @@ fn math() {
     assert_eq!("494C553B", result.factors[0]);
     assert_eq!("53911073", result.factors[1]);
 
+    let result = client.request::<_, ResultOfFactorize>(
+        "crypto.factorize",
+        ParamsOfFactorize {
+            composite: "10".into(),
+        },
+    );
+    assert!(result.is_err());
+
     let result: ResultOfModularPower = client.request(
         "crypto.modular_power",
         ParamsOfModularPower {

--- a/ton_client/client/src/json_interface/runtime.rs
+++ b/ton_client/client/src/json_interface/runtime.rs
@@ -43,7 +43,7 @@ impl RuntimeHandlers {
             sync_handlers: HashMap::new(),
             async_handlers: HashMap::new(),
             api: API {
-                version: "1.0.0".into(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
                 modules: Vec::new(),
             },
         };

--- a/ton_client/platforms/ton-client-node-js/Cargo.toml
+++ b/ton_client/platforms/ton-client-node-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_node_js"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["TON Labs"]
 license = "Apache-2.0"
 

--- a/ton_client/platforms/ton-client-web/Cargo.toml
+++ b/ton_client/platforms/ton-client-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client_wasm"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2018"
 description = "TON Client WASM binding"
 license = "Apache-2.0"

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_sdk"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/toncli/Cargo.toml
+++ b/toncli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toncli"
-version = "1.1.1"
+version = "1.1.2"
 description = "TON CLient Command Line Tool"
 authors = ["TON DEV SOLUTIONS LTD <support@tonlabs.io>"]
 repository = "https://github.com/tonlabs/TON-SDK"


### PR DESCRIPTION
### Fixed
- `client.factorize` doesn't panic on invalid challenge
- `client.get_api_reference` returns proper version
- ABI JSON with explicit function ID is parsed properly