### PR TITLE
1.2.0 global runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+## 1.2.0 Nov 20, 2020
+
+### Fixed
+- panic after `tc_destroy_context` call. Now all contexts use global async runtime
+
 ## 1.1.0 Nov 3, 2020
 
 ### New

--- a/ton_client/build-lib.js
+++ b/ton_client/build-lib.js
@@ -26,7 +26,7 @@ function root_path(...items) {
     return path.resolve(root, ...(items.reduce((a, x) => a.concat(x), [])));
 }
 
-const ton_client_toml = fs.readFileSync(path.join(__dirname, '..', 'client', 'Cargo.toml'))
+const ton_client_toml = fs.readFileSync(path.join(__dirname, '..', 'ton_client', 'Cargo.toml'))
     .toString();
 const toml_version = /^\s*version\s*=\s*"([0-9.]+)"\s*$/gm.exec(ton_client_toml)[1] || '';
 const version = toml_version.split('.').join('_');

--- a/ton_client/build.js
+++ b/ton_client/build.js
@@ -26,7 +26,7 @@ main(async () => {
         darwin: [['lib{}.dylib', '']],
     };
     for (const [src, dstSuffix] of platformNames[platform] || []) {
-        const target = ['..', '..', 'target', 'release', src.replace('{}', 'ton_client')];
+        const target = ['..', 'target', 'release', src.replace('{}', 'ton_client')];
         await postBuild(target, platform);
         await gz(
             target,


### PR DESCRIPTION
### Fixed
- panic after `tc_destroy_context` call. Now all contexts use global async runtime