### PR TITLE
1.5.2 wait resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+
+## 1.5.2 Dec 30, 2020
+
+### Fixed
+- `net` module functions wait for `net.resume` call instead of returning error if called while the module is suspended
+
 ## 1.5.1 Dec 28, 2020
 
 ### Fixed

--- a/ton_client/src/tests/mod.rs
+++ b/ton_client/src/tests/mod.rs
@@ -263,6 +263,14 @@ impl TestClient {
         "0:2bb4a0e8391e7ea8877f4825064924bd41ce110fce97e939d3323999e1efbb13".into()
     }
 
+    pub fn network_giver() -> String {
+        if Self::node_se() {
+            Self::giver_address()
+        } else {
+            Self::wallet_address()
+        }
+    }
+
     pub fn wallet_keys() -> Option<KeyPair> {
         if Self::node_se() {
             return None;


### PR DESCRIPTION
- `net` module functions wait for `net.resume` call instead of returning error if called while the module is suspended