### PR TITLE
1.5.2 rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - `net` module functions wait for `net.resume` call instead of returning error if called while the module is suspended
 
+### Documentation
+- How to work with `Application Objects` [specification](docs/app_objects.md) added 
+
 ## 1.5.1 Dec 28, 2020
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 All notable changes to this project will be documented in this file.
 
+
+## 1.5.2 Dec 30, 2020
+
+### Fixed
+- `net` module functions wait for `net.resume` call instead of returning error if called while the module is suspended
+
 ## 1.5.1 Dec 28, 2020
 
 ### Fixed

--- a/docs/app_objects.md
+++ b/docs/app_objects.md
@@ -1,0 +1,160 @@
+# Notes for binding generators
+
+Binding generator must detect functions that accept application objects.
+
+Application object interaction protocol and functions that accept app objects have the following signatures in core:
+
+```rust
+/// Methods of the Foo interface with parameters
+enum ParamsOfAppFoo {
+    CallWithParamsAndResult { a: String, b: String },
+    CallWithParams { a: String, b: String },
+    CallWithResult,
+    CallWithoutParamsAndResult,
+    NotifyWithParams { a: String, b: String },
+    NotifyWithoutParams
+}
+
+/// Method results of the Foo interface
+enum ResultOfAppFoo {
+    CallWithParamsAndResult { c: String },
+    CallWithParams,
+    CallWithResult { c: String },
+    CallWithoutParamsAndResult,
+}
+
+/// API function that accepts an application object as a parameter
+async fn foo(
+		context: Arc<ClientContext>,
+		params: ParamsOfFoo,
+		obj: AppObject<ParamsOfAppFoo, ResultOfAppFoo>,
+) -> ClientResult<()> {}
+```
+
+It means when a function accepts an application-implemented object, from that point library will have access to the methods of this object.
+
+### How to detect
+
+Function contains parameter with generic type `AppObject<foo_module.ParamsOfAppFoo, foo_module.ResultOfAppFoo>`. 
+
+### Generated code
+
+Generator must produce:
+
+- interface declaration;
+- interface dispatcher;
+- function that accept application object.
+
+### Interface declaration
+
+```tsx
+export type ParamsOfAppFooCallWithParamsAndResult {
+    a: string,
+    b: string,
+}
+
+export type ResultOfAppFooCallWithParamsAndResult {
+    c: string,
+}
+
+export type ParamsOfAppFooCallWithParams {
+    a: string,
+    b: string,
+}
+
+export type ResultOfAppFooCallWithResult {
+    c: string,
+}
+
+export type ParamsOfAppFooNotifyWithParams {
+    a: string,
+    b: string,
+}
+
+export interface AppFoo {
+    call_with_params_and_result(params: ParamsOfFooWithParamsAndResult): Promise<ResultOfFooWithParamsAndResult>,
+    call_with_params(params: ParamsOfFooWithParams): Promise<void>,
+    call_with_result(): Promise<ResultOfFooWithResult>,
+    notify_with_params(params: ParamsoOfFooNotifyWithParams),
+    notify_without_params(),
+}
+```
+
+- Interface  `Foo` is extracted from the name of the first generic arg of the `AppObject<foo_module.ParamsOfAppFoo, foo_module.ResultOfAppFoo>`. Note that a generic arg name is a fully qualified name so you must remove the module name first. In the example above the first arg name is `foo_module.ParamsOfAppFoo.` After removing module name we have `ParamsOfAppFoo`. Then we must remove the prefix `ParamsOf`. The rest of the name contains the interface name `Foo`.
+- To collect a list of interface methods we must collect variant names from enum `foo_module.ParamsOfAppFoo`. Each variant of `ParamsOfAppFoo` represents the interface method. Respectively each variant of `ResultOfAppFoo` represents the result of the interface method. If interface method has no `ResultOfAppFoo` then such method is a notify method –  no waiting for the response is needed.
+- The name of the interface method  is constructed from the name of the variant by using a simple rule `PascalStyleName` → `snake_style_name`. So the variant `CallWithParamsAndResult` will be converted to `call_with_params_and_result`.
+- If a function has a result then this function must return `Promise` and perform asynchronous execution.
+
+### Interface dispatcher
+
+The implementation of the wrapper method is more difficult than regular. It must pass dispatching `responseHandler` to the library. Library will call this handler every time when it requires to call the application object. Two response types are used for calling application objects: `3` for calling methods which return result and `4` for notifiyng without awaiting any result. When response type `4` is passed, data contains enum `ParamsOfAppFoo`. When  `3` is passed, data contains struct `ParamsOfAppRequest`  where `request_data` field contains `ParamsOfAppFoo`
+
+```tsx
+type ParamsOfAppRequest {
+		app_request_id: number,
+		request_data: any,
+}
+```
+
+Generator must define special dispatch helper for application object invocation:
+
+```tsx
+async function dispatchFoo(obj: Foo, params: ParamsOfAppFoo, app_request_id: number | null, client: TonClient) {
+    try {
+        let result = undefined;
+		    switch (params.type) {
+		    case 'CallWithParamsAndResult':
+		        result = await obj.call_with_params_and_result(params);
+		        break;
+		    case 'CallWithParams':
+		        await obj.call_with_params(params);
+		        break;
+		    case 'CallWithResult':
+		        result = await obj.call_with_result();
+		        break;
+		    case 'CallWithoutParamsAndResult':
+		        await obj.call_with_result();
+		        break;
+		    case 'NotifyWithParams':
+		        obj.notify_with_params(params);
+		        break;
+		    case 'NotifyWithoutParams':
+		        obj.notify_without_params();
+		        break;
+				}
+				if (app_request_id) {
+            client.resolve_app_request({ app_request_id, result: { type: 'Ok', result: { type: params.type, ...result }}});
+        }
+    }
+    catch (error) {
+        if (app_request_id) {
+            client.resolve_app_request({ app_request_id, result: { type: 'Error', text: error.message }});
+        }
+    }
+}
+
+```
+
+### Functions with application object
+
+The `obj` parameter must be declared instead of the source `obj: AppObject<ParamsOfAppFoo, ResultOfAppFoo>`.
+
+Wrapper implementation with dispatcher must be generated as:
+
+```tsx
+type ParamsOfFoo {
+		...
+}
+
+export class AppFoo {
+    foo(params: ParamsOfFoo, obj: Foo): Promise<ResultOfFoo> {
+        return this.client.request('foo', params, (params, responseType) => {
+            if (responseType === 3) {
+                 dispatchFoo(obj, params.request_data, params.app_request_id, this);
+            } else if (responseType === 4) {
+                 dispatchFoo(obj, params, null, this);
+            }
+        }
+    }
+}
+```

--- a/docs/app_objects.md
+++ b/docs/app_objects.md
@@ -1,4 +1,4 @@
-# Notes for binding generators
+# How to work with Application Objects in binding generators
 
 Binding generator must detect functions that accept application objects.
 

--- a/docs/json_interface.md
+++ b/docs/json_interface.md
@@ -293,4 +293,7 @@ type ParamsOfAppRequest {
 Here `request_data` is some data describing the request and `app_request_id` is ID of the request, which should be used for request result resolving. After  the request is processed application should call `client.resolve_app_request` function passing `app_request_id` used in the request and result of processing.
 
 In case if response type is `4`, `params_json` contains serialized notification data without any wrappers. Application processes notification in the way it needs. No response is needed for SDK. 
-Find out how to work with Application Objects in binding generators in this [specification](https://github.com/tonlabs/TON-SDK/blob/master/docs/app_objects.md).
+
+### How to work with Application Objects in binding generators
+
+Find out how to work with Application Objects in binding generators in this [specification](app_objects.md).

--- a/docs/json_interface.md
+++ b/docs/json_interface.md
@@ -292,4 +292,5 @@ type ParamsOfAppRequest {
 
 Here `request_data` is some data describing the request and `app_request_id` is ID of the request, which should be used for request result resolving. After  the request is processed application should call `client.resolve_app_request` function passing `app_request_id` used in the request and result of processing.
 
-In case if response type is `4`, `params_json` contains serialized notification data without any wrappers. Application processes notification in the way it needs. No response is needed for SDK.
+In case if response type is `4`, `params_json` contains serialized notification data without any wrappers. Application processes notification in the way it needs. No response is needed for SDK. 
+Find out how to work with Application Objects in binding generators in this [specification](https://github.com/tonlabs/TON-SDK/blob/master/docs/app_objects.md).

--- a/docs/mod_processing.md
+++ b/docs/mod_processing.md
@@ -144,7 +144,8 @@ timeout: SDK recreates the message, sends it and processes it again.
 The intermediate events, such as `WillFetchFirstBlock`, `WillSend`, `DidSend`,
 `WillFetchNextBlock`, etc - are switched on/off by `send_events` flag
 and logged into the supplied callback function.
-The retry configuration parameters are defined in client's `NetworkConfig`.
+
+The retry configuration parameters are defined in the client's `NetworkConfig` and `AbiConfig`.
 
 If contract's ABI does not include "expire" header
 then, if no transaction is found within the network timeout (see config parameter ), exits with error.

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_client"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["Michael Vlasov"]
 edition = "2018"
 license = "Apache-2.0"

--- a/ton_client/src/tests/mod.rs
+++ b/ton_client/src/tests/mod.rs
@@ -263,6 +263,14 @@ impl TestClient {
         "0:2bb4a0e8391e7ea8877f4825064924bd41ce110fce97e939d3323999e1efbb13".into()
     }
 
+    pub fn network_giver() -> String {
+        if Self::node_se() {
+            Self::giver_address()
+        } else {
+            Self::wallet_address()
+        }
+    }
+
     pub fn wallet_keys() -> Option<KeyPair> {
         if Self::node_se() {
             return None;

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton_sdk"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/toncli/Cargo.toml
+++ b/toncli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toncli"
-version = "1.5.1"
+version = "1.5.2"
 description = "TON CLient Command Line Tool"
 authors = ["TON DEV SOLUTIONS LTD <support@tonlabs.io>"]
 repository = "https://github.com/tonlabs/TON-SDK"

--- a/tools/api.json
+++ b/tools/api.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.5.2",
   "modules": [
     {
       "name": "client",
@@ -6037,7 +6037,7 @@
         {
           "name": "process_message",
           "summary": "Creates message, sends it to the network and monitors its processing.",
-          "description": "Creates ABI-compatible message,\nsends it to the network and monitors for the result transaction.\nDecodes the output messages' bodies.\n\nIf contract's ABI includes \"expire\" header, then\nSDK implements retries in case of unsuccessful message delivery within the expiration\ntimeout: SDK recreates the message, sends it and processes it again.\n\nThe intermediate events, such as `WillFetchFirstBlock`, `WillSend`, `DidSend`,\n`WillFetchNextBlock`, etc - are switched on/off by `send_events` flag\nand logged into the supplied callback function.\nThe retry configuration parameters are defined in client's `NetworkConfig`.\n\nIf contract's ABI does not include \"expire\" header\nthen, if no transaction is found within the network timeout (see config parameter ), exits with error.",
+          "description": "Creates ABI-compatible message,\nsends it to the network and monitors for the result transaction.\nDecodes the output messages' bodies.\n\nIf contract's ABI includes \"expire\" header, then\nSDK implements retries in case of unsuccessful message delivery within the expiration\ntimeout: SDK recreates the message, sends it and processes it again.\n\nThe intermediate events, such as `WillFetchFirstBlock`, `WillSend`, `DidSend`,\n`WillFetchNextBlock`, etc - are switched on/off by `send_events` flag\nand logged into the supplied callback function.\n\nThe retry configuration parameters are defined in the client's `NetworkConfig` and `AbiConfig`.\n\nIf contract's ABI does not include \"expire\" header\nthen, if no transaction is found within the network timeout (see config parameter ), exits with error.",
           "params": [
             {
               "name": "context",


### PR DESCRIPTION
### Fixed
- `net` module functions wait for `net.resume` call instead of returning error if called while the module is suspended

### Documentation
- How to work with `Application Objects` specification added 