### PR TITLE
Encode message using function id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### New
 
-- `tuple_list_as_array` parameter in `tvm.run_get` function which controls lists representation. 
+- `tuple_list_as_array` parameter in `tvm.run_get` function which controls lists representation.
 Default is stack-like based on nested tuples. If set to `true` then returned lists are encoded as plain arrays.
 This reduces stack size requirements for long lists.
-    
+- `function_name` field of `CallSet` structure can be the name or id (as string in hex) of calling function.
+
 ## 1.8.0 Feb 11, 2021
 
 ### New
 
 - **Debot Module**:
     - Added new built-in interface `Msg` which allows to send external message to blockchain and sign it with supplied keypair.
-    
+
 ### Fixed
 
 - `crypto.hdkey_public_from_xprv` used compressed 33-byte form instead of normal 32-byte.

--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -4,7 +4,7 @@ use crate::abi::{Abi, Error, FunctionHeader, Signer};
 use crate::boc::internal::{get_boc_hash, deserialize_cell_from_boc};
 use crate::client::ClientContext;
 use crate::crypto::internal::decode_public_key;
-use crate::encoding::{account_decode, account_encode, hex_decode};
+use crate::encoding::{account_decode, account_encode, decode_abi_number, hex_decode};
 use crate::error::ClientResult;
 use serde_json::Value;
 use std::str::FromStr;
@@ -162,7 +162,7 @@ impl CallSet {
             )?
         };
 
-        let func = match u32::from_str_radix(&self.function_name, 16) {
+        let func = match decode_abi_number::<u32>(&self.function_name) {
             Ok(id) => {
                 &contract
                     .function_by_id(id, true)

--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -163,9 +163,15 @@ impl CallSet {
         };
 
         let func = match u32::from_str_radix(&self.function_name, 16) {
-            Ok(id) => &contract.function_by_id(id, true).map_err(|e| Error::invalid_function_id(&self.function_name, e))?.name,
+            Ok(id) => {
+                &contract
+                    .function_by_id(id, true)
+                    .map_err(|e| Error::invalid_function_id(&self.function_name, e))?
+                    .name
+            }
             Err(_) => &self.function_name,
-        }.clone();
+        }
+        .clone();
 
         Ok(FunctionCallSet {
             abi: abi.to_string(),

--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -50,6 +50,7 @@ impl DeploySet {
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType, Default)]
 pub struct CallSet {
     /// Function name that is being called.
+    /// Or function id encoded as string in hex (starting with 0x).
     pub function_name: String,
 
     /// Function header.

--- a/ton_client/src/abi/errors.rs
+++ b/ton_client/src/abi/errors.rs
@@ -14,6 +14,7 @@ pub enum ErrorCode {
     RequiredPublicKeyMissingForFunctionHeader = 309,
     InvalidSigner = 310,
     InvalidAbi = 311,
+    InvalidFunctionId = 312,
 }
 
 pub struct Error;
@@ -92,6 +93,13 @@ impl Error {
         error(
             ErrorCode::InvalidTvcImage,
             format!("Invalid TVC image: {}", err),
+        )
+    }
+
+    pub fn invalid_function_id<E: Display>(func_id: &str, err: E) -> ClientError {
+        error(
+            ErrorCode::InvalidFunctionId,
+            format!("Invalid function {}: {}", func_id, err),
         )
     }
 }

--- a/ton_client/src/abi/tests.rs
+++ b/ton_client/src/abi/tests.rs
@@ -622,7 +622,18 @@ async fn test_encode_internal_message() -> Result<()> {
         &client,
         &abi,
         Some(CallSet {
-            function_name: format!("{:x}", func_id),
+            function_name: format!("0x{:x}", func_id),
+            header: None,
+            input: None,
+        }),
+        Some(expected_boc),
+    ).await?;
+
+    test_encode_internal_message_run(
+        &client,
+        &abi,
+        Some(CallSet {
+            function_name: format!("{}", func_id),
             header: None,
             input: None,
         }),


### PR DESCRIPTION
`CallSet.function_name` field can be a hex number encoded as string.