### PR TITLE
Encode msg empty body

### DIFF
--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use ton_abi::Contract;
 use ton_block::{MsgAddressInt, MsgAddressIntOrNone, CurrencyCollection};
 use ton_sdk::{ContractImage, FunctionCallSet};
-use ton_types::BuilderData;
 
 //--------------------------------------------------------------------------- encode_deploy_message
 
@@ -617,7 +616,7 @@ pub async  fn encode_internal_message(
                 ihr_disabled,
                 bounce,
                 value,
-                BuilderData::new().into()
+                None,
             )
             .map_err(|err| abi::Error::encode_run_message_failed(err, ""))?;
             (message.serialized_message, address)

--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::str::FromStr;
 use std::sync::Arc;
 use ton_abi::Contract;
-use ton_block::{MsgAddressInt, CurrencyCollection};
+use ton_block::{MsgAddressInt, MsgAddressIntOrNone, CurrencyCollection};
 use ton_sdk::{ContractImage, FunctionCallSet};
 use ton_types::BuilderData;
 
@@ -278,6 +278,7 @@ fn encode_deploy(
 }
 
 fn encode_int_deploy(
+    src: MsgAddressIntOrNone,
     context: std::sync::Arc<ClientContext>,
     abi: &str,
     image: ContractImage,
@@ -289,6 +290,7 @@ fn encode_int_deploy(
 ) -> ClientResult<(Vec<u8>, MsgAddressInt)> {
     let address = image.msg_address(workchain_id);
     let message = ton_sdk::Contract::get_int_deploy_message_bytes(
+        src,
         call_set.to_function_call_set(pubkey, None, &context, &abi, true)?,
         image,
         workchain_id,
@@ -318,6 +320,7 @@ fn encode_empty_deploy(
 }
 
 fn encode_empty_int_deploy(
+    src: MsgAddressIntOrNone,
     image: ContractImage,
     workchain_id: i32,
     ihr_disabled: bool,
@@ -325,6 +328,7 @@ fn encode_empty_int_deploy(
 ) -> ClientResult<(Vec<u8>, MsgAddressInt)> {
     let address = image.msg_address(workchain_id);
     let message = ton_sdk::Contract::construct_int_deploy_message_no_constructor(
+        src,
         image,
         workchain_id,
         ihr_disabled,
@@ -542,6 +546,10 @@ pub async  fn encode_internal_message(
     context: std::sync::Arc<ClientContext>,
     params: ParamsOfEncodeInternalMessage,
 ) -> ClientResult<ResultOfEncodeInternalMessage> {
+    let src_address = match params.src_address {
+        Some(addr) => MsgAddressIntOrNone::Some(account_decode(&addr)?),
+        None => MsgAddressIntOrNone::None,
+    };
     let ihr_disabled = !params.enable_ihr.unwrap_or(false);
     let bounce = params.bounce.unwrap_or(true);
 
@@ -564,6 +572,7 @@ pub async  fn encode_internal_message(
         let public = required_public_key(public)?;
         if let Some(call_set) = &params.call_set {
             encode_int_deploy(
+                src_address,
                 Arc::clone(&context),
                 &abi,
                 image,
@@ -574,7 +583,7 @@ pub async  fn encode_internal_message(
                 bounce,
             )?
         } else {
-            encode_empty_int_deploy(image, workchain_id, ihr_disabled, bounce)?
+            encode_empty_int_deploy(src_address, image, workchain_id, ihr_disabled, bounce)?
         }
     } else {
         let address = params
@@ -592,6 +601,7 @@ pub async  fn encode_internal_message(
                 .json_string()?;
             let message = ton_sdk::Contract::construct_call_int_message_json(
                 address.clone(),
+                src_address,
                 ihr_disabled,
                 bounce,
                 value,
@@ -603,6 +613,7 @@ pub async  fn encode_internal_message(
         } else {
             let message = ton_sdk::Contract::construct_int_message_with_body(
                 address.clone(),
+                src_address,
                 ihr_disabled,
                 bounce,
                 value,

--- a/ton_sdk/src/contract.rs
+++ b/ton_sdk/src/contract.rs
@@ -353,7 +353,7 @@ impl Contract {
             ihr_disabled,
             bounce,
             value,
-            msg_body.into()
+            Some(msg_body.into()),
         )
     }
 
@@ -363,7 +363,7 @@ impl Contract {
         ihr_disabled: bool,
         bounce: bool,
         value: CurrencyCollection,
-        msg_body: SliceData,
+        msg_body: Option<SliceData>,
     ) -> Result<SdkMessage> {
         let msg = Self::create_int_message(ihr_disabled, bounce, dst_address.clone(), src_address, value, msg_body)?;
         let (body, id) = Self::serialize_message(&msg)?;
@@ -608,7 +608,7 @@ impl Contract {
         dst: MsgAddressInt,
         src: MsgAddressIntOrNone,
         value: CurrencyCollection,
-        msg_body: SliceData,
+        msg_body: Option<SliceData>,
     ) -> Result<TvmMessage> {
         let msg_header = InternalMessageHeader {
             ihr_disabled,
@@ -620,7 +620,7 @@ impl Contract {
         };
 
         let mut msg = TvmMessage::with_int_header(msg_header);
-        msg.set_body(msg_body);
+        msg_body.map(|body| msg.set_body(body));
 
         Ok(msg)
     }

--- a/ton_sdk/src/contract.rs
+++ b/ton_sdk/src/contract.rs
@@ -137,7 +137,7 @@ impl ContractImage {
 
         Ok(Self { state_init, id })
     }
-    
+
     pub fn get_public_key(&self) -> Result<Option<PublicKey>> {
         let data = &self.state_init.data.as_ref().ok_or_else(
             || SdkError::InvalidData {
@@ -344,7 +344,23 @@ impl Contract {
             None,
         )?;
 
-        let msg = Self::create_int_message(ihr_disabled, bounce, address.clone(), value, msg_body.into())?;
+        Self::construct_int_message_with_body(
+            address,
+            ihr_disabled,
+            bounce,
+            value,
+            msg_body.into()
+        )
+    }
+
+    pub fn construct_int_message_with_body(
+        address: MsgAddressInt,
+        ihr_disabled: bool,
+        bounce: bool,
+        value: CurrencyCollection,
+        msg_body: SliceData,
+    ) -> Result<SdkMessage> {
+        let msg = Self::create_int_message(ihr_disabled, bounce, address.clone(), value, msg_body)?;
         let (body, id) = Self::serialize_message(&msg)?;
         Ok(SdkMessage {
             id,


### PR DESCRIPTION
Modify `encode_internal_message`. 
Allow to build msg with empty body.
Allow to define src address.