### PR TITLE
1.13.1 fix wasm timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.1] – 2021-04-21
+
+### Fixed
+
+- `processing.process_message` and `processing.wait_for_transaction` functions did not work on WASM
+
 ## [1.13.0] – 2021-04-15
 
 ### New

--- a/ton_client/src/client/wasm_client_env.rs
+++ b/ton_client/src/client/wasm_client_env.rs
@@ -13,9 +13,7 @@
 
 use super::{Error, FetchMethod, FetchResult, WebSocket};
 use crate::error::ClientResult;
-use std::pin::Pin;
 use futures::{Future, FutureExt, SinkExt, StreamExt};
-use futures::task::{Context, Poll};
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -59,37 +57,51 @@ where
         .map_err(|err| Error::can_not_receive_spawned_result(err))
 }
 
-struct Timer {
+struct Timer{
     window: Window,
-    timer_id: i32,
-    future: Pin<Box<dyn Future<Output=ClientResult<()>> + 'static>>
+    timer_id: Option<i32>,
+    // keep closure to fix memory leak
+    _on_timer: Closure<dyn FnMut() -> ()>,
 }
 
 impl Timer {
-    pub fn new(
-        window: Window,
-        timer_id: i32,
-        future: impl Future<Output=ClientResult<()>> + 'static
-    ) -> Self {
-        Self {
-            window,
-            timer_id,
-            future: Box::pin(future)
-        }
+    pub fn new(timeout_ms: u64) -> ClientResult<(Self, impl Future<Output=ClientResult<()>>)> {
+        let window =
+            web_sys::window().ok_or_else(|| Error::set_timer_error("Can not get `window`"))?;
+
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let on_timer = Closure::once(move || {
+            let _ = sender.send(());
+        });
+
+        let timer_id = window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                on_timer.as_ref().unchecked_ref(),
+                std::cmp::min(timeout_ms, std::i32::MAX as u64) as i32,
+            )
+            .map_err(|_| Error::set_timer_error("Can not set timer"))?;
+
+        Ok((
+            Self {
+                window,
+                timer_id: Some(timer_id),
+                _on_timer: on_timer,
+            },
+            receiver
+                .map(|val| val.map_err(|_| Error::set_timer_error("Can not receive timer result")))
+        ))
     }
-}
 
-impl Future for Timer {
-    type Output = ClientResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Future::poll(Pin::<&mut Timer>::into_inner(self).future.as_mut(), cx)
+    pub fn forget(&mut self) {
+        self.timer_id = None;
     }
 }
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        self.window.clear_timeout_with_handle(self.timer_id);
+        if let Some(timer_id) = self.timer_id {
+            self.window.clear_timeout_with_handle(timer_id);
+        }
     }
 }
 
@@ -102,27 +114,9 @@ impl ClientEnv {
 
     /// Sets timer for provided time interval
     pub async fn set_timer_internal(ms: u64) -> ClientResult<()> {
-        let window =
-            web_sys::window().ok_or_else(|| Error::set_timer_error("Can not get `window`"))?;
-
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        let on_timer = Closure::once(move || {
-            let _ = sender.send(());
-        });
-
-        let timer_id = window
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                on_timer.as_ref().unchecked_ref(),
-                std::cmp::min(ms, std::i32::MAX as u64) as i32,
-            )
-            .map_err(|_| Error::set_timer_error("Can not set timer"))?;
-
-        Timer::new(
-            window,
-            timer_id,
-            receiver
-                .map(|val| val.map_err(|_| Error::set_timer_error("Can not receive timer result")))
-        ).await
+        let (mut timer, future) = Timer::new(ms)?;
+        future.await?;
+        Ok(timer.forget())
     }
 
     /// Connects to the websocket endpoint


### PR DESCRIPTION
- `processing.process_message` and `processing.wait_for_transaction` functions did not work on WASM