### PR TITLE
Http timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [1.20.0] – 2021-07-16
 
+### New
+- Now all requests to GraphQL are limited with timeout to react on unexpected server unavailability.
+Existing timeouts in waiting functions keep the same behaviour. All other requests timeout now can 
+be set with `net.default_http_timeout` config parameter
+
 ### Fixed
 - Deployment with empty signer in cases of public key set in TVC or deploy set.
 

--- a/ton_client/src/net/server_link.rs
+++ b/ton_client/src/net/server_link.rs
@@ -483,7 +483,6 @@ impl ServerLink {
                 current_endpoint = Some(self.state.get_query_endpoint().await?.clone());
                 current_endpoint.as_ref().unwrap()
             };
-
             let result = self
                 .client_env
                 .fetch(
@@ -491,7 +490,7 @@ impl ServerLink {
                     FetchMethod::Post,
                     Some(headers.clone()),
                     Some(request.clone()),
-                    query.timeout,
+                    query.timeout.or(Some(self.config.default_http_timeout)),
                 )
                 .await;
 

--- a/ton_client/src/net/types.rs
+++ b/ton_client/src/net/types.rs
@@ -58,6 +58,10 @@ pub fn default_max_latency() -> u32 {
     60000
 }
 
+pub fn default_default_http_timeout() -> u32 {
+    10000
+}
+
 fn deserialize_network_retries_count<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<i8, D::Error> {
@@ -116,6 +120,12 @@ fn deserialize_latency_detection_frequency<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<u32, D::Error> {
     Ok(Option::deserialize(deserializer)?.unwrap_or(default_latency_detection_frequency()))
+}
+
+fn deserialize_default_http_timeout<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<u32, D::Error> {
+    Ok(Option::deserialize(deserializer)?.unwrap_or(default_default_http_timeout()))
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ApiType)]
@@ -228,6 +238,17 @@ pub struct NetworkConfig {
     )]
     pub max_latency: u32,
 
+    /// Default timeout for http requests. Is is used when no timeout specified for the request to 
+    /// limit the answer waiting time. If no answer received during the timeout requests ends with
+    /// error.
+    ///
+    /// Must be specified in milliseconds. Default is 10000 (10 sec).
+    #[serde(
+        default = "default_default_http_timeout",
+        deserialize_with = "deserialize_default_http_timeout"
+    )]
+    pub default_http_timeout: u32,
+
     /// Access key to GraphQL API. At the moment is not used in production.
     pub access_key: Option<String>,
 }
@@ -247,6 +268,7 @@ impl Default for NetworkConfig {
             sending_endpoint_count: default_sending_endpoint_count(),
             latency_detection_interval: default_latency_detection_frequency(),
             max_latency: default_max_latency(),
+            default_http_timeout: default_default_http_timeout(),
             access_key: None,
         }
     }


### PR DESCRIPTION
- Now all requests to GraphQL are limited with timeout to react on unexpected server unavailability.
Existing timeouts in waiting functions keep the same behaviour. All other requests timeout now can 
be set with `net.default_http_timeout` config parameter