### PR TITLE
Reconnect on graphql internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New
 - Information about used endpoint is added to subscription errors.
+- Graphql response error codes 500-599 are treated as retriable network errors
 
 ## [1.21.2] – 2021-08-25
 

--- a/ton_client/src/client/errors.rs
+++ b/ton_client/src/client/errors.rs
@@ -58,6 +58,10 @@ impl Error {
             || error.code == ErrorCode::WebsocketReceiveError as u32
             || error.code == ErrorCode::WebsocketSendError as u32
             || error.code == ErrorCode::HttpRequestSendError as u32
+            || (error.code == crate::net::ErrorCode::GraphqlError as u32
+                && error.data["server_code"].as_i64() >= Some(500)
+                && error.data["server_code"].as_i64() <= Some(599)
+            )
     }
 
     pub fn internal_error<E: Display>(message: E) -> ClientError {

--- a/ton_client/src/net/errors.rs
+++ b/ton_client/src/net/errors.rs
@@ -81,7 +81,7 @@ impl Error {
         )
     }
 
-    fn try_get_message(server_errors: &[Value]) -> (Option<String>, Option<i64>) {
+    fn try_get_message_and_code(server_errors: &[Value]) -> (Option<String>, Option<i64>) {
         for error in server_errors.iter() {
             if let Some(message) = error["message"].as_str() {
                 return (Some(message.to_string()), error["extensions"]["exception"]["code"].as_i64());
@@ -91,7 +91,7 @@ impl Error {
     }
 
     pub fn graphql_server_error(operation: Option<&str>, errors: &[Value]) -> ClientError {
-        let (message, code) = Self::try_get_message(errors);
+        let (message, code) = Self::try_get_message_and_code(errors);
         let operation = operation.unwrap_or("server returned");
         let mut err = error(
             ErrorCode::GraphqlError,

--- a/ton_client/src/net/tests.rs
+++ b/ton_client/src/net/tests.rs
@@ -695,11 +695,41 @@ async fn retry_query_on_network_errors() {
         .status(502, "")
         .election(now, 1000)
         .blocks("3")
+        .ok(&json!({
+            "errors": [
+              {
+                "message": "Service Unavailable",
+                "locations": [
+                  {
+                    "line": 2,
+                    "column": 3
+                  }
+                ],
+                "path": [
+                  "counterparties"
+                ],
+                "extensions": {
+                  "code": "INTERNAL_SERVER_ERROR",
+                  "exception": {
+                    "source": "graphql",
+                    "code": 503
+                  }
+                }
+              }
+            ],
+            "data": {
+              "blocks": null
+            }
+          })
+        .to_string())
+        .election(now, 1000)
+        .blocks("4")
         .reset_client(&client)
         .await;
     assert_eq!(query_block_id(&client).await, "1");
     assert_eq!(query_block_id(&client).await, "2");
     assert_eq!(query_block_id(&client).await, "3");
+    assert_eq!(query_block_id(&client).await, "4");
 }
 
 #[tokio::test(core_threads = 2)]

--- a/ton_client/src/net/websocket_link.rs
+++ b/ton_client/src/net/websocket_link.rs
@@ -373,7 +373,7 @@ impl LinkHandler {
             GraphQLMessageFromServer::ConnectionError { error } => {
                 next_phase = self
                     .handle_network_error(
-                        Error::graphql_server_error("connection", &vec![error]),
+                        Error::graphql_server_error(Some("connection"), &vec![error]),
                         false,
                     )
                     .await;
@@ -381,7 +381,7 @@ impl LinkHandler {
             GraphQLMessageFromServer::Data { id, data, errors } => {
                 let event = if let Some(errors) = errors {
                     GraphQLQueryEvent::Error(
-                        Error::graphql_server_error("operation", &errors)
+                        Error::graphql_server_error(Some("operation"), &errors)
                             .add_network_url_from_state(&self.state)
                             .await,
                     )
@@ -394,7 +394,7 @@ impl LinkHandler {
                 self.notify_with_remove(
                     true,
                     &id,
-                    GraphQLQueryEvent::Error(Error::graphql_error(error)),
+                    GraphQLQueryEvent::Error(Error::graphql_server_error(None, &[error])),
                 )
                 .await;
             }


### PR DESCRIPTION
- Graphql response error codes 500-599 are treated as retriable network errors