### PR TITLE
Fetch timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### New
 - Added `abi.encode_boc` function to encode parameters with values to BOC, using ABI types.
 - Added support of `address` type in `boc.encode_boc`.
+- All fetch requests are now called with timeouts to prevent freezing in case of infinite answer.
 
 
 ## [1.28.0] – 2021-12-24

--- a/ton_client/src/client/std_client_env.rs
+++ b/ton_client/src/client/std_client_env.rs
@@ -192,7 +192,7 @@ impl ClientEnv {
         method: FetchMethod,
         headers: Option<HashMap<String, String>>,
         body: Option<String>,
-        timeout_ms: Option<u32>,
+        timeout_ms: u32,
     ) -> ClientResult<FetchResult> {
         #[cfg(test)]
         {
@@ -204,16 +204,15 @@ impl ClientEnv {
         let method = Method::from_str(method.as_str())
             .map_err(|err| Error::http_request_create_error(err))?;
 
-        let mut request = self.http_client.request(method, url);
+        let mut request = self.http_client
+            .request(method, url)
+            .timeout(std::time::Duration::from_millis(timeout_ms as u64));
 
         if let Some(headers) = headers {
             request = request.headers(Self::string_map_to_header_map(headers)?);
         }
         if let Some(body) = body {
             request = request.body(body);
-        }
-        if let Some(timeout) = timeout_ms {
-            request = request.timeout(std::time::Duration::from_millis(timeout as u64));
         }
 
         let response = request

--- a/ton_client/src/client/wasm_client_env.rs
+++ b/ton_client/src/client/wasm_client_env.rs
@@ -271,7 +271,7 @@ impl ClientEnv {
         method: FetchMethod,
         headers: Option<HashMap<String, String>>,
         body: Option<String>,
-        timeout_ms: Option<u32>,
+        timeout_ms: u32,
     ) -> ClientResult<FetchResult> {
         let mut opts = RequestInit::new();
         opts.method(method.as_str());
@@ -301,19 +301,14 @@ impl ClientEnv {
                 Err(err) => Err(Error::http_request_send_error(js_error_to_string(err))),
             });
 
-        let resp_result = match timeout_ms {
-            Some(timeout) => {
-                futures::select!(
-                    result = resp_future => result,
-                    timer = Self::set_timer_internal(timeout as u64).fuse() => {
-                        Err(timer
-                            .err()
-                            .unwrap_or(Error::http_request_send_error("fetch operation timeout")))
-                    }
-                )
-            }
-            None => resp_future.await
-        };
+        let resp_result = futures::select!(
+                result = resp_future => result,
+                timer = Self::set_timer_internal(timeout as u64).fuse() => {
+                    Err(timer
+                        .err()
+                        .unwrap_or(Error::http_request_send_error("fetch operation timeout")))
+                }
+            );
 
         let response: Response = resp_result?.dyn_into().map_err(|_| {
             Error::http_request_parse_error("Can not cast response to `Response` struct")
@@ -376,7 +371,7 @@ impl ClientEnv {
         method: FetchMethod,
         headers: Option<HashMap<String, String>>,
         body: Option<String>,
-        timeout_ms: Option<u32>,
+        timeout_ms: u32,
     ) -> ClientResult<FetchResult> {
         let url = url.to_owned();
         execute_spawned(move || async move {

--- a/ton_client/src/debot/network_interface.rs
+++ b/ton_client/src/debot/network_interface.rs
@@ -108,7 +108,7 @@ impl NetworkInterface {
                     None
                 },
                 body,
-                None,
+                self.client.config.network.query_timeout,
             )
             .await
             .map_err(|e| format!("{}", e))?;

--- a/ton_client/src/net/endpoint.rs
+++ b/ton_client/src/net/endpoint.rs
@@ -77,6 +77,7 @@ impl Endpoint {
         client_env: &ClientEnv,
         query_url: &str,
         query: &str,
+        timeout: u32,
     ) -> ClientResult<(Value, String, Option<String>)> {
         let response = client_env
             .fetch(
@@ -84,7 +85,7 @@ impl Endpoint {
                 FetchMethod::Get,
                 None,
                 None,
-                None,
+                timeout,
             )
             .await?;
         let query_url = response.url.trim_end_matches(query).to_owned();
@@ -100,7 +101,7 @@ impl Endpoint {
         let address = Self::expand_address(address);
         let info_request_time = client_env.now_ms();
         let (info, query_url, ip_address) =
-            Self::fetch_info_with_url(client_env, &address, QUERY_INFO_SCHEMA).await?;
+            Self::fetch_info_with_url(client_env, &address, QUERY_INFO_SCHEMA, config.query_timeout).await?;
         let subscription_url = query_url
             .replace("https://", "wss://")
             .replace("http://", "ws://");
@@ -126,7 +127,7 @@ impl Endpoint {
         if self.version() >= V_0_39_0 {
             let info_request_time = client_env.now_ms();
             let (info, _, _) =
-                Self::fetch_info_with_url(client_env, &self.query_url, QUERY_INFO_METRICS).await?;
+                Self::fetch_info_with_url(client_env, &self.query_url, QUERY_INFO_METRICS, config.query_timeout).await?;
             self.apply_server_info(client_env, config, info_request_time, &info)?;
         }
         Ok(())

--- a/ton_client/src/net/server_link.rs
+++ b/ton_client/src/net/server_link.rs
@@ -78,14 +78,14 @@ pub(crate) struct NetworkState {
     time_checked: AtomicBool,
 }
 
-async fn query_by_url(client_env: &ClientEnv, address: &str, query: &str) -> ClientResult<Value> {
+async fn query_by_url(client_env: &ClientEnv, address: &str, query: &str, timeout: u32) -> ClientResult<Value> {
     let response = client_env
         .fetch(
             &format!("{}?query={}", address, query),
             FetchMethod::Get,
             None,
             None,
-            None,
+            timeout,
         )
         .await?;
 
@@ -484,7 +484,7 @@ impl ServerLink {
                     FetchMethod::Post,
                     Some(headers.clone()),
                     Some(request.clone()),
-                    query.timeout.or(Some(self.config.query_timeout)),
+                    query.timeout.unwrap_or(self.config.query_timeout),
                 )
                 .await;
 
@@ -650,6 +650,7 @@ impl ServerLink {
             &self.client_env,
             &endpoint.query_url,
             "%7Binfo%7Bendpoints%7D%7D",
+            self.config.query_timeout,
         )
         .await
         .add_network_url(&self)


### PR DESCRIPTION
- All fetch requests are now called with timeouts to prevent freezing in case of infinite answer.